### PR TITLE
read all the stat info, even when it exceeds 2048 bytes.

### DIFF
--- a/ganglia/zookeeper_ganglia.py
+++ b/ganglia/zookeeper_ganglia.py
@@ -57,7 +57,13 @@ class ZooKeeperServer(object):
         s.connect(self._address)
         s.send(cmd)
 
-        data = s.recv(2048)
+        # read all the data until the socket closes
+        data = ""
+        newdata = s.recv(2048)
+        while newdata:
+            data += newdata
+            newdata = s.recv(2048)
+
         s.close()
 
         return data


### PR DESCRIPTION
When the number of connected clients exceeds a small number, the client stats (example below) use up all 2048 bytes that are read off the socket. The result is that the actual metrics this script is looking for (latency etc.) are never read.

 /10.32.73.187:43992[1](queued=0,recved=635,sent=635)
 /10.158.12.47:60001[1](queued=0,recved=4208,sent=4208)
 /10.82.237.49:35073[1](queued=0,recved=19,sent=19)
^^^^ these lines repeat and blow out the buffer, preventing it from reading vvvv
Latency min/avg/max: 0/3/299
Received: 2206216
Sent: 2276700
