### PR TITLE
read all the stat info, even when it exceeds 2048 bytes.

### DIFF
--- a/ganglia/zookeeper_ganglia.py
+++ b/ganglia/zookeeper_ganglia.py
@@ -57,7 +57,13 @@ class ZooKeeperServer(object):
         s.connect(self._address)
         s.send(cmd)
 
-        data = s.recv(2048)
+        # read all the data until the socket closes
+        data = ""
+        newdata = s.recv(2048)
+        while newdata:
+            data += newdata
+            newdata = s.recv(2048)
+
         s.close()
 
         return data


### PR DESCRIPTION
The list of connected clients blows out the first 2048 bytes before you can get to the interesting stuff.
